### PR TITLE
Add GitHub CLI (gh) role

### DIFF
--- a/roles/gh-cli/tasks/main.yaml
+++ b/roles/gh-cli/tasks/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: "Install GitHub CLI"
+  community.general.homebrew:
+    state: latest
+    name: gh


### PR DESCRIPTION
## Summary
- Adds a new Ansible role to install GitHub CLI (gh) via Homebrew
- Enables command-line interaction with GitHub repositories

🤖 Generated with [Claude Code](https://claude.ai/code)